### PR TITLE
Update RBKCD.psm1

### DIFF
--- a/RBKCD.psm1
+++ b/RBKCD.psm1
@@ -83,6 +83,10 @@ param(
     [PSCredential]
     $DomainCCred = (Get-Credential -Message 'DomainC credential')
 )
+    $CurrentHostVersion=((Get-CimInstance -ClassName CIM_OperatingSystem).Version).Split('.')
+    If(($CurrentHostVersion[0] -lt 6) -or (($CurrentHostVersion[0] -eq 6) -and ($CurrentHostVersion[1] -le 1)))
+    {Throw 'Windows 8 is the minimum required version to run this cmdlet!'} 
+    
     Set-ADComputer -Identity $ServerC.Substring(0,$ServerC.IndexOf('.')) -Credential $DomainCCred -Server $ServerC.Substring($ServerC.IndexOf('.')+1) -PrincipalsAllowedToDelegateToAccount $null
 }
 
@@ -140,6 +144,10 @@ param(
     [PSCredential]
     $DomainCCred
 )
+    $CurrentHostVersion=((Get-CimInstance -ClassName CIM_OperatingSystem).Version).Split('.')
+    If(($CurrentHostVersion[0] -lt 6) -or (($CurrentHostVersion[0] -eq 6) -and ($CurrentHostVersion[1] -le 1)))
+    {Throw 'Windows 8 is the minimum required version to run this cmdlet!'} 
+    
     If (!$PSBoundParameters.ContainsKey('DomainCCred')) {$DomainCCred = $DomainBCred = $Credential}
 
     # Split out the hostname and domain name portions of the FQDN where appropriate


### PR DESCRIPTION
Enable-RBKCD et Disable-RBKCD throw an error when launched on a Windows 7 computer.
They work fine with versions above.

`Set-ADComputer : A parameter cannot be found that matches parameter name 'PrincipalsAllowedToDelegateToAccount'.
At C:\Program Files\WindowsPowerShell\Modules\RBKCD\RBKCD.psm1:182 char:41
+ ... ADComputer -Identity $C -PrincipalsAllowedToDelegateToAccount $B -Cre ...
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-ADComputer], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.ActiveDirectory.Management.Commands.SetADComputer`

My change checks the current host version.